### PR TITLE
edit: add schema id, schema name, catalog name in TableData

### DIFF
--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -146,7 +146,7 @@ impl<'a> Alterer<'a> {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                schema_id: self.table_data.schema_id,
+                extr_info: self.table_data.extr_info.clone(),
             }
         };
         self.instance
@@ -280,7 +280,7 @@ impl<'a> Alterer<'a> {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                schema_id: self.table_data.schema_id,
+                extr_info: self.table_data.extr_info.clone(),
             }
         };
         self.instance

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -146,6 +146,7 @@ impl<'a> Alterer<'a> {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
+                schema_id: self.table_data.schema_id,
             }
         };
         self.instance
@@ -279,6 +280,7 @@ impl<'a> Alterer<'a> {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
+                schema_id: self.table_data.schema_id,
             }
         };
         self.instance

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -146,7 +146,7 @@ impl<'a> Alterer<'a> {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: self.table_data.extr_info.clone(),
+                table_catalog_info: self.table_data.table_catalog_info.clone(),
             }
         };
         self.instance
@@ -280,7 +280,7 @@ impl<'a> Alterer<'a> {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: self.table_data.extr_info.clone(),
+                table_catalog_info: self.table_data.table_catalog_info.clone(),
             }
         };
         self.instance

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -66,7 +66,7 @@ impl Closer {
             space_id: self.space.id,
             table_id: table_data.id,
             shard_id: table_data.shard_info.shard_id,
-            schema_id: table_data.schema_id,
+            extr_info: table_data.extr_info.clone(),
         };
         self.manifest
             .do_snapshot(snapshot_request)

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -66,7 +66,7 @@ impl Closer {
             space_id: self.space.id,
             table_id: table_data.id,
             shard_id: table_data.shard_info.shard_id,
-            extr_info: table_data.extr_info.clone(),
+            table_catalog_info: table_data.table_catalog_info.clone(),
         };
         self.manifest
             .do_snapshot(snapshot_request)

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -66,6 +66,7 @@ impl Closer {
             space_id: self.space.id,
             table_id: table_data.id,
             shard_id: table_data.shard_info.shard_id,
+            schema_id: table_data.schema_id,
         };
         self.manifest
             .do_snapshot(snapshot_request)

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -90,6 +90,7 @@ impl Instance {
                 space_id: space.id,
                 table_id: request.table_id,
                 table_name: request.params.table_name.clone(),
+                catalog_name: request.params.catalog_name.clone(),
                 schema: request.params.table_schema,
                 opts: table_opts,
             });

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -90,7 +90,6 @@ impl Instance {
                 space_id: space.id,
                 table_id: request.table_id,
                 table_name: request.params.table_name.clone(),
-                catalog_name: request.params.catalog_name.clone(),
                 schema: request.params.table_schema,
                 opts: table_opts,
             });

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -96,7 +96,7 @@ impl Instance {
             MetaEditRequest {
                 shard_info: TableShardInfo::new(request.shard_id),
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: TableCatalogInfo {
+                table_catalog_info: TableCatalogInfo {
                     schema_id: request.schema_id,
                     schema_name: request.params.schema_name,
                     catalog_name: request.params.catalog_name,

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     manifest::meta_edit::{AddTableMeta, MetaEdit, MetaEditRequest, MetaUpdate},
     space::SpaceRef,
-    table::data::{TableDataExtraneousInfo, TableDataRef, TableShardInfo},
+    table::data::{TableCatalogInfo, TableDataRef, TableShardInfo},
     table_options, TableOptions,
 };
 
@@ -96,7 +96,7 @@ impl Instance {
             MetaEditRequest {
                 shard_info: TableShardInfo::new(request.shard_id),
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: TableDataExtraneousInfo {
+                extr_info: TableCatalogInfo {
                     schema_id: request.schema_id,
                     schema_name: request.params.schema_name,
                     catalog_name: request.params.catalog_name,

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -96,6 +96,7 @@ impl Instance {
             MetaEditRequest {
                 shard_info: TableShardInfo::new(request.shard_id),
                 meta_edit: MetaEdit::Update(meta_update),
+                schema_id: request.schema_id,
             }
         };
         self.space_store

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     manifest::meta_edit::{AddTableMeta, MetaEdit, MetaEditRequest, MetaUpdate},
     space::SpaceRef,
-    table::data::{TableDataRef, TableShardInfo},
+    table::data::{TableDataExtraneousInfo, TableDataRef, TableShardInfo},
     table_options, TableOptions,
 };
 
@@ -96,7 +96,11 @@ impl Instance {
             MetaEditRequest {
                 shard_info: TableShardInfo::new(request.shard_id),
                 meta_edit: MetaEdit::Update(meta_update),
-                schema_id: request.schema_id,
+                extr_info: TableDataExtraneousInfo {
+                    schema_id: request.schema_id,
+                    schema_name: request.params.schema_name,
+                    catalog_name: request.params.catalog_name,
+                },
             }
         };
         self.space_store

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -85,7 +85,7 @@ impl Dropper {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: TableCatalogInfo {
+                table_catalog_info: TableCatalogInfo {
                     schema_id: request.schema_id,
                     schema_name: request.schema_name,
                     catalog_name: request.catalog_name,

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     manifest::meta_edit::{DropTableMeta, MetaEdit, MetaEditRequest, MetaUpdate},
     space::SpaceRef,
-    table::data::TableDataExtraneousInfo,
+    table::data::TableCatalogInfo,
 };
 
 pub(crate) struct Dropper {
@@ -85,7 +85,7 @@ impl Dropper {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: TableDataExtraneousInfo {
+                extr_info: TableCatalogInfo {
                     schema_id: request.schema_id,
                     schema_name: request.schema_name,
                     catalog_name: request.catalog_name,

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -84,6 +84,7 @@ impl Dropper {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
+                schema_id: request.schema_id,
             }
         };
         self.space_store

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     manifest::meta_edit::{DropTableMeta, MetaEdit, MetaEditRequest, MetaUpdate},
     space::SpaceRef,
+    table::data::TableDataExtraneousInfo,
 };
 
 pub(crate) struct Dropper {
@@ -84,7 +85,11 @@ impl Dropper {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                schema_id: request.schema_id,
+                extr_info: TableDataExtraneousInfo {
+                    schema_id: request.schema_id,
+                    schema_name: request.schema_name,
+                    catalog_name: request.catalog_name,
+                },
             }
         };
         self.space_store

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -344,6 +344,7 @@ impl FlushTask {
                 let edit_req = MetaEditRequest {
                     shard_info: table_data.shard_info,
                     meta_edit: MetaEdit::Update(meta_update),
+                    schema_id: table_data.schema_id,
                 };
                 self.space_store
                     .manifest
@@ -364,6 +365,7 @@ impl FlushTask {
                 MetaEditRequest {
                     shard_info: table_data.shard_info,
                     meta_edit: MetaEdit::Update(meta_update),
+                    schema_id: table_data.schema_id,
                 }
             };
             self.space_store
@@ -466,6 +468,7 @@ impl FlushTask {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
+                schema_id: self.table_data.schema_id,
             }
         };
         // Update manifest and remove immutable memtables
@@ -805,6 +808,7 @@ impl SpaceStore {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
+                schema_id: table_data.schema_id,
             }
         };
         self.manifest

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -350,7 +350,7 @@ impl FlushTask {
                 let edit_req = MetaEditRequest {
                     shard_info: table_data.shard_info,
                     meta_edit: MetaEdit::Update(meta_update),
-                    schema_id: table_data.schema_id,
+                    extr_info: table_data.extr_info.clone(),
                 };
                 self.space_store
                     .manifest
@@ -371,7 +371,7 @@ impl FlushTask {
                 MetaEditRequest {
                     shard_info: table_data.shard_info,
                     meta_edit: MetaEdit::Update(meta_update),
-                    schema_id: table_data.schema_id,
+                    extr_info: table_data.extr_info.clone(),
                 }
             };
             self.space_store
@@ -481,7 +481,7 @@ impl FlushTask {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                schema_id: self.table_data.schema_id,
+                extr_info: self.table_data.extr_info.clone(),
             }
         };
         // Update manifest and remove immutable memtables
@@ -824,7 +824,7 @@ impl SpaceStore {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                schema_id: table_data.schema_id,
+                extr_info: table_data.extr_info.clone(),
             }
         };
         self.manifest

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -350,7 +350,7 @@ impl FlushTask {
                 let edit_req = MetaEditRequest {
                     shard_info: table_data.shard_info,
                     meta_edit: MetaEdit::Update(meta_update),
-                    extr_info: table_data.extr_info.clone(),
+                    table_catalog_info: table_data.table_catalog_info.clone(),
                 };
                 self.space_store
                     .manifest
@@ -371,7 +371,7 @@ impl FlushTask {
                 MetaEditRequest {
                     shard_info: table_data.shard_info,
                     meta_edit: MetaEdit::Update(meta_update),
-                    extr_info: table_data.extr_info.clone(),
+                    table_catalog_info: table_data.table_catalog_info.clone(),
                 }
             };
             self.space_store
@@ -481,7 +481,7 @@ impl FlushTask {
             MetaEditRequest {
                 shard_info: self.table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: self.table_data.extr_info.clone(),
+                table_catalog_info: self.table_data.table_catalog_info.clone(),
             }
         };
         // Update manifest and remove immutable memtables
@@ -824,7 +824,7 @@ impl SpaceStore {
             MetaEditRequest {
                 shard_info: table_data.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: table_data.extr_info.clone(),
+                table_catalog_info: table_data.table_catalog_info.clone(),
             }
         };
         self.manifest

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -461,7 +461,7 @@ impl ShardOpener {
             space_id,
             table_id: id,
             shard_id,
-            extr_info: TableCatalogInfo {
+            table_catalog_info: TableCatalogInfo {
                 schema_id,
                 schema_name,
                 catalog_name,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -44,7 +44,7 @@ use crate::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, ScanOptions},
         file::FilePurger,
     },
-    table::data::{TableDataExtraneousInfo, TableDataRef},
+    table::data::{TableCatalogInfo, TableDataRef},
     table_meta_set_impl::TableMetaSetImpl,
     RecoverMode,
 };
@@ -461,7 +461,7 @@ impl ShardOpener {
             space_id,
             table_id: id,
             shard_id,
-            extr_info: TableDataExtraneousInfo {
+            extr_info: TableCatalogInfo {
                 schema_id,
                 schema_name,
                 catalog_name,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -448,9 +448,11 @@ impl ShardOpener {
 
         // Load manifest, also create a new snapshot at startup.
         let table_id = table_def.id;
-        let space_id = engine::build_space_id(table_def.schema_id);
+        let schema_id = table_def.schema_id;
+        let space_id = engine::build_space_id(schema_id);
         let load_req = LoadRequest {
             space_id,
+            schema_id,
             table_id,
             shard_id,
         };

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -44,7 +44,7 @@ use crate::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, ScanOptions},
         file::FilePurger,
     },
-    table::data::TableDataRef,
+    table::data::{TableDataExtraneousInfo, TableDataRef},
     table_meta_set_impl::TableMetaSetImpl,
     RecoverMode,
 };
@@ -448,14 +448,24 @@ impl ShardOpener {
         );
 
         // Load manifest, also create a new snapshot at startup.
-        let table_id = table_def.id;
-        let schema_id = table_def.schema_id;
+        let TableDef {
+            catalog_name,
+            schema_name,
+            schema_id,
+            id,
+            name: _,
+        } = table_def.clone();
+
         let space_id = engine::build_space_id(schema_id);
         let load_req = LoadRequest {
             space_id,
-            schema_id,
-            table_id,
+            table_id: id,
             shard_id,
+            extr_info: TableDataExtraneousInfo {
+                schema_id,
+                schema_name,
+                catalog_name,
+            },
         };
         manifest.recover(&load_req).await.context(ReadMetaUpdate {
             table_id: table_def.id,

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -1265,7 +1265,11 @@ mod tests {
                 .await;
 
             manifest
-                .do_snapshot_internal(ctx.table_catalog_info.schema_id.as_u32(), table_id, location)
+                .do_snapshot_internal(
+                    ctx.table_catalog_info.schema_id.as_u32(),
+                    table_id,
+                    location,
+                )
                 .await
                 .unwrap();
 
@@ -1326,7 +1330,11 @@ mod tests {
 
             let location = WalLocation::new(DEFAULT_SHARD_ID as u64, table_id.as_u64());
             manifest
-                .do_snapshot_internal(ctx.table_catalog_info.schema_id.as_u32(), table_id, location)
+                .do_snapshot_internal(
+                    ctx.table_catalog_info.schema_id.as_u32(),
+                    table_id,
+                    location,
+                )
                 .await
                 .unwrap();
             for i in 500..550 {

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -856,6 +856,7 @@ mod tests {
                 },
                 &purger,
                 mem_size_options,
+                "test_catalog".to_string()
             )
             .unwrap();
 
@@ -949,6 +950,7 @@ mod tests {
                 table_name,
                 schema: common_types::tests::build_schema(),
                 opts: TableOptions::default(),
+                catalog_name: "test_catalog".to_string()
             })
         }
 

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -491,6 +491,7 @@ impl Manifest for ManifestImpl {
         let MetaEditRequest {
             shard_info,
             meta_edit,
+            schema_id: _,
         } = request.clone();
 
         let meta_update = MetaUpdate::try_from(meta_edit).box_err()?;
@@ -546,6 +547,7 @@ impl Manifest for ManifestImpl {
             let request = MetaEditRequest {
                 shard_info: TableShardInfo::new(load_req.shard_id),
                 meta_edit,
+                schema_id: load_req.schema_id,
             };
             self.table_meta_set.apply_edit_to_table(request)?;
         }
@@ -817,6 +819,7 @@ mod tests {
             let MetaEditRequest {
                 shard_info: _,
                 meta_edit,
+                schema_id,
             } = request;
 
             match meta_edit {
@@ -845,6 +848,7 @@ mod tests {
                     id: TableId::new(0),
                     name: "test_table".to_string(),
                     schema: default_schema(),
+                    schema_id,
                     shard_id: 0,
                 },
                 table_opts,
@@ -1012,6 +1016,7 @@ mod tests {
                 MetaEditRequest {
                     shard_info,
                     meta_edit: MetaEdit::Update(add_table.clone()),
+                    schema_id: self.schema_id,
                 }
             };
 
@@ -1036,6 +1041,7 @@ mod tests {
                 MetaEditRequest {
                     shard_info,
                     meta_edit: MetaEdit::Update(drop_table.clone()),
+                    schema_id: self.schema_id,
                 }
             };
             manifest.apply_edit(edit_req).await.unwrap();
@@ -1060,6 +1066,7 @@ mod tests {
                 MetaEditRequest {
                     shard_info,
                     meta_edit: MetaEdit::Update(version_edit.clone()),
+                    schema_id: self.schema_id,
                 }
             };
             manifest.apply_edit(edit_req).await.unwrap();
@@ -1115,6 +1122,7 @@ mod tests {
                 MetaEditRequest {
                     shard_info,
                     meta_edit: MetaEdit::Update(alter_options.clone()),
+                    schema_id: self.schema_id,
                 }
             };
             manifest.apply_edit(edit_req).await.unwrap();
@@ -1137,6 +1145,7 @@ mod tests {
                 MetaEditRequest {
                     shard_info,
                     meta_edit: MetaEdit::Update(alter_schema.clone()),
+                    schema_id: self.schema_id,
                 }
             };
 
@@ -1164,6 +1173,7 @@ mod tests {
                 table_id,
                 shard_id: DEFAULT_SHARD_ID,
                 space_id: ctx.schema_id.as_u32(),
+                schema_id: ctx.schema_id,
             };
             let expected_table_manifest_data = manifest_data_builder.build();
             ctx.check_table_manifest_data(&load_req, &expected_table_manifest_data)
@@ -1255,6 +1265,7 @@ mod tests {
             .await;
             let load_req = LoadRequest {
                 space_id: ctx.schema_id.as_u32(),
+                schema_id: ctx.schema_id,
                 table_id,
                 shard_id: DEFAULT_SHARD_ID,
             };
@@ -1275,6 +1286,7 @@ mod tests {
             let table_id = ctx.alloc_table_id();
             let load_req = LoadRequest {
                 space_id: ctx.schema_id.as_u32(),
+                schema_id: ctx.schema_id,
                 table_id,
                 shard_id: DEFAULT_SHARD_ID,
             };
@@ -1431,6 +1443,7 @@ mod tests {
         let log_store = MemLogStore::from_updates(&input_updates);
         let snapshot_store = MemSnapshotStore::new();
         let snapshot_data_provider = ctx.mock_provider.clone();
+        let schema_id = ctx.schema_id;
 
         ctx.runtime.block_on(async move {
             let log_store = log_store;
@@ -1445,6 +1458,7 @@ mod tests {
                 let request = MetaEditRequest {
                     shard_info: TableShardInfo::new(DEFAULT_SHARD_ID),
                     meta_edit: MetaEdit::Update(update.clone()),
+                    schema_id,
                 };
                 snapshot_provider.apply_edit_to_table(request).unwrap();
             }
@@ -1482,6 +1496,7 @@ mod tests {
                 let request = MetaEditRequest {
                     shard_info: TableShardInfo::new(DEFAULT_SHARD_ID),
                     meta_edit: MetaEdit::Update(update.clone()),
+                    schema_id,
                 };
                 snapshot_provider.apply_edit_to_table(request).unwrap();
             }

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -760,7 +760,7 @@ mod tests {
         },
         sst::file::tests::FilePurgerMocker,
         table::data::{
-            tests::default_schema, MemSizeOptions, TableConfig, TableData, TableDataExtraneousInfo,
+            tests::default_schema, MemSizeOptions, TableConfig, TableData, TableCatalogInfo,
             TableDesc, TableShardInfo,
         },
         MetricsOptions, TableOptions,
@@ -837,7 +837,7 @@ mod tests {
                 }
             }
 
-            let TableDataExtraneousInfo {
+            let TableCatalogInfo {
                 schema_id,
                 schema_name,
                 catalog_name,
@@ -880,7 +880,7 @@ mod tests {
         dir: PathBuf,
         runtime: Arc<Runtime>,
         options: Options,
-        extr_info: TableDataExtraneousInfo,
+        extr_info: TableCatalogInfo,
         table_seq_gen: TableSeqGenerator,
         mock_provider: Arc<MockProviderImpl>,
     }
@@ -899,7 +899,7 @@ mod tests {
                 dir: dir.into_path(),
                 runtime,
                 options,
-                extr_info: TableDataExtraneousInfo {
+                extr_info: TableCatalogInfo {
                     schema_id,
                     catalog_name: "test_catalog".to_string(),
                     schema_name: "public".to_string(),

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -856,7 +856,6 @@ mod tests {
                 },
                 &purger,
                 mem_size_options,
-                "test_catalog".to_string()
             )
             .unwrap();
 
@@ -950,7 +949,6 @@ mod tests {
                 table_name,
                 schema: common_types::tests::build_schema(),
                 opts: TableOptions::default(),
-                catalog_name: "test_catalog".to_string()
             })
         }
 

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -760,7 +760,7 @@ mod tests {
         },
         sst::file::tests::FilePurgerMocker,
         table::data::{
-            tests::default_schema, MemSizeOptions, TableConfig, TableData, TableCatalogInfo,
+            tests::default_schema, MemSizeOptions, TableCatalogInfo, TableConfig, TableData,
             TableDesc, TableShardInfo,
         },
         MetricsOptions, TableOptions,

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -166,6 +166,8 @@ pub struct AddTableMeta {
     pub table_name: String,
     /// Schema of the table
     pub schema: Schema,
+    /// Name of catalog
+    pub catalog_name: String,
     // Options needed to persist
     pub opts: TableOptions,
 }

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -25,7 +25,7 @@ use common_types::{
 use macros::define_result;
 use prost::Message;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
-use table_engine::table::TableId;
+use table_engine::table::{SchemaId, TableId};
 use wal::log_batch::{Payload, PayloadDecoder};
 
 use crate::{
@@ -530,4 +530,5 @@ impl TryFrom<MetaEdit> for MetaSnapshot {
 pub struct MetaEditRequest {
     pub shard_info: TableShardInfo,
     pub meta_edit: MetaEdit,
+    pub schema_id: SchemaId,
 }

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -33,7 +33,7 @@ use crate::{
     space::SpaceId,
     sst::manager::FileId,
     table::{
-        data::{MemTableId, TableDataExtraneousInfo, TableShardInfo},
+        data::{MemTableId, TableCatalogInfo, TableShardInfo},
         version::TableVersionMeta,
         version_edit::{AddFile, DeleteFile, VersionEdit},
     },
@@ -530,5 +530,5 @@ impl TryFrom<MetaEdit> for MetaSnapshot {
 pub struct MetaEditRequest {
     pub shard_info: TableShardInfo,
     pub meta_edit: MetaEdit,
-    pub extr_info: TableDataExtraneousInfo,
+    pub extr_info: TableCatalogInfo,
 }

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -166,8 +166,6 @@ pub struct AddTableMeta {
     pub table_name: String,
     /// Schema of the table
     pub schema: Schema,
-    /// Name of catalog
-    pub catalog_name: String,
     // Options needed to persist
     pub opts: TableOptions,
 }

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -530,5 +530,5 @@ impl TryFrom<MetaEdit> for MetaSnapshot {
 pub struct MetaEditRequest {
     pub shard_info: TableShardInfo,
     pub meta_edit: MetaEdit,
-    pub extr_info: TableCatalogInfo,
+    pub table_catalog_info: TableCatalogInfo,
 }

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -25,7 +25,7 @@ use common_types::{
 use macros::define_result;
 use prost::Message;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
-use table_engine::table::{SchemaId, TableId};
+use table_engine::table::TableId;
 use wal::log_batch::{Payload, PayloadDecodeContext, PayloadDecoder};
 
 use crate::{
@@ -33,7 +33,7 @@ use crate::{
     space::SpaceId,
     sst::manager::FileId,
     table::{
-        data::{MemTableId, TableShardInfo},
+        data::{MemTableId, TableDataExtraneousInfo, TableShardInfo},
         version::TableVersionMeta,
         version_edit::{AddFile, DeleteFile, VersionEdit},
     },
@@ -530,5 +530,5 @@ impl TryFrom<MetaEdit> for MetaSnapshot {
 pub struct MetaEditRequest {
     pub shard_info: TableShardInfo,
     pub meta_edit: MetaEdit,
-    pub schema_id: SchemaId,
+    pub extr_info: TableDataExtraneousInfo,
 }

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -23,13 +23,14 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use common_types::table::ShardId;
 use generic_error::GenericResult;
-use table_engine::table::TableId;
+use table_engine::table::{SchemaId, TableId};
 
 use crate::{manifest::meta_edit::MetaEditRequest, space::SpaceId};
 
 #[derive(Debug)]
 pub struct LoadRequest {
     pub space_id: SpaceId,
+    pub schema_id: SchemaId,
     pub table_id: TableId,
     pub shard_id: ShardId,
 }

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -25,9 +25,7 @@ use common_types::table::ShardId;
 use generic_error::GenericResult;
 use table_engine::table::TableId;
 
-use crate::{
-    manifest::meta_edit::MetaEditRequest, space::SpaceId, table::data::TableCatalogInfo,
-};
+use crate::{manifest::meta_edit::MetaEditRequest, space::SpaceId, table::data::TableCatalogInfo};
 
 #[derive(Debug)]
 pub struct LoadRequest {

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -23,16 +23,18 @@ use std::{fmt, sync::Arc};
 use async_trait::async_trait;
 use common_types::table::ShardId;
 use generic_error::GenericResult;
-use table_engine::table::{SchemaId, TableId};
+use table_engine::table::TableId;
 
-use crate::{manifest::meta_edit::MetaEditRequest, space::SpaceId};
+use crate::{
+    manifest::meta_edit::MetaEditRequest, space::SpaceId, table::data::TableDataExtraneousInfo,
+};
 
 #[derive(Debug)]
 pub struct LoadRequest {
     pub space_id: SpaceId,
-    pub schema_id: SchemaId,
     pub table_id: TableId,
     pub shard_id: ShardId,
+    pub extr_info: TableDataExtraneousInfo,
 }
 
 pub type SnapshotRequest = LoadRequest;

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -26,7 +26,7 @@ use generic_error::GenericResult;
 use table_engine::table::TableId;
 
 use crate::{
-    manifest::meta_edit::MetaEditRequest, space::SpaceId, table::data::TableDataExtraneousInfo,
+    manifest::meta_edit::MetaEditRequest, space::SpaceId, table::data::TableCatalogInfo,
 };
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ pub struct LoadRequest {
     pub space_id: SpaceId,
     pub table_id: TableId,
     pub shard_id: ShardId,
-    pub extr_info: TableDataExtraneousInfo,
+    pub extr_info: TableCatalogInfo,
 }
 
 pub type SnapshotRequest = LoadRequest;

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -32,7 +32,7 @@ pub struct LoadRequest {
     pub space_id: SpaceId,
     pub table_id: TableId,
     pub shard_id: ShardId,
-    pub extr_info: TableCatalogInfo,
+    pub table_catalog_info: TableCatalogInfo,
 }
 
 pub type SnapshotRequest = LoadRequest;

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -177,7 +177,7 @@ pub struct TableData {
     pub name: String,
     /// Schema of this table
     schema: Mutex<Schema>,
-    pub extr_info: TableCatalogInfo,
+    pub table_catalog_info: TableCatalogInfo,
     /// Space id of this table
     pub space_id: SpaceId,
 
@@ -332,7 +332,7 @@ impl TableData {
             id,
             name,
             schema: Mutex::new(schema),
-            extr_info: TableCatalogInfo {
+            table_catalog_info: TableCatalogInfo {
                 schema_id,
                 schema_name,
                 catalog_name,
@@ -368,7 +368,7 @@ impl TableData {
         config: TableConfig,
         mem_size_options: MemSizeOptions,
         allocator: IdAllocator,
-        extr_info: TableCatalogInfo,
+        table_catalog_info: TableCatalogInfo,
     ) -> Result<Self> {
         let TableConfig {
             preflush_write_buffer_size_ratio,
@@ -391,7 +391,7 @@ impl TableData {
             id: add_meta.table_id,
             name: add_meta.table_name,
             schema: Mutex::new(add_meta.schema),
-            extr_info,
+            table_catalog_info,
             space_id: add_meta.space_id,
             mutable_limit,
             mutable_limit_write_buffer_ratio: preflush_write_buffer_size_ratio,
@@ -665,7 +665,7 @@ impl TableData {
             MetaEditRequest {
                 shard_info: self.shard_info,
                 meta_edit: MetaEdit::Update(meta_update),
-                extr_info: self.extr_info.clone(),
+                table_catalog_info: self.table_catalog_info.clone(),
             }
         };
         // table version's max file id will be update when apply this meta update.

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -153,13 +153,13 @@ pub struct TableConfig {
 }
 
 #[derive(Debug, Clone)]
-pub struct TableDataExtraneousInfo {
+pub struct TableCatalogInfo {
     pub schema_id: SchemaId,
     pub schema_name: String,
     pub catalog_name: String,
 }
 
-impl TableDataExtraneousInfo {
+impl TableCatalogInfo {
     pub fn new(schema_id: SchemaId, schema_name: String, catalog_name: String) -> Self {
         Self {
             schema_id,
@@ -177,7 +177,7 @@ pub struct TableData {
     pub name: String,
     /// Schema of this table
     schema: Mutex<Schema>,
-    pub extr_info: TableDataExtraneousInfo,
+    pub extr_info: TableCatalogInfo,
     /// Space id of this table
     pub space_id: SpaceId,
 
@@ -332,7 +332,7 @@ impl TableData {
             id,
             name,
             schema: Mutex::new(schema),
-            extr_info: TableDataExtraneousInfo {
+            extr_info: TableCatalogInfo {
                 schema_id,
                 schema_name,
                 catalog_name,
@@ -368,7 +368,7 @@ impl TableData {
         config: TableConfig,
         mem_size_options: MemSizeOptions,
         allocator: IdAllocator,
-        extr_info: TableDataExtraneousInfo,
+        extr_info: TableCatalogInfo,
     ) -> Result<Self> {
         let TableConfig {
             preflush_write_buffer_size_ratio,

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -157,8 +157,6 @@ pub struct TableData {
     pub name: String,
     /// Schema of this table
     schema: Mutex<Schema>,
-    /// Name of catalog
-    pub catalog_name: String,
     /// Space id of this table
     pub space_id: SpaceId,
 
@@ -273,7 +271,6 @@ impl TableData {
         config: TableConfig,
         purger: &FilePurger,
         mem_size_options: MemSizeOptions,
-        catalog_name: String,
     ) -> Result<Self> {
         // TODO: Validate TableOptions, such as bucket_duration >=
         // segment_duration and bucket_duration is aligned to segment_duration
@@ -318,7 +315,6 @@ impl TableData {
             memtable_factory,
             mem_usage_collector: mem_size_options.collector,
             current_version,
-            catalog_name,
             last_sequence: AtomicU64::new(0),
             last_memtable_id: AtomicU64::new(0),
             allocator: IdAllocator::new(0, 0, DEFAULT_ALLOC_STEP),
@@ -365,7 +361,6 @@ impl TableData {
             id: add_meta.table_id,
             name: add_meta.table_name,
             schema: Mutex::new(add_meta.schema),
-            catalog_name: add_meta.catalog_name,
             space_id: add_meta.space_id,
             mutable_limit,
             mutable_limit_write_buffer_ratio: preflush_write_buffer_size_ratio,
@@ -924,7 +919,6 @@ pub mod tests {
                 },
                 &purger,
                 mem_size_options,
-                params.catalog_name.clone()
             )
             .unwrap()
         }

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -157,6 +157,8 @@ pub struct TableData {
     pub name: String,
     /// Schema of this table
     schema: Mutex<Schema>,
+    /// Name of catalog
+    pub catalog_name: String,
     /// Space id of this table
     pub space_id: SpaceId,
 
@@ -271,6 +273,7 @@ impl TableData {
         config: TableConfig,
         purger: &FilePurger,
         mem_size_options: MemSizeOptions,
+        catalog_name: String,
     ) -> Result<Self> {
         // TODO: Validate TableOptions, such as bucket_duration >=
         // segment_duration and bucket_duration is aligned to segment_duration
@@ -315,6 +318,7 @@ impl TableData {
             memtable_factory,
             mem_usage_collector: mem_size_options.collector,
             current_version,
+            catalog_name,
             last_sequence: AtomicU64::new(0),
             last_memtable_id: AtomicU64::new(0),
             allocator: IdAllocator::new(0, 0, DEFAULT_ALLOC_STEP),
@@ -361,6 +365,7 @@ impl TableData {
             id: add_meta.table_id,
             name: add_meta.table_name,
             schema: Mutex::new(add_meta.schema),
+            catalog_name: add_meta.catalog_name,
             space_id: add_meta.space_id,
             mutable_limit,
             mutable_limit_write_buffer_ratio: preflush_write_buffer_size_ratio,
@@ -919,6 +924,7 @@ pub mod tests {
                 },
                 &purger,
                 mem_size_options,
+                params.catalog_name.clone()
             )
             .unwrap()
         }

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -38,7 +38,7 @@ use crate::{
     sst::file::FilePurgerRef,
     table::{
         data::{
-            MemSizeOptions, TableConfig, TableData, TableDataExtraneousInfo, TableDataRef,
+            MemSizeOptions, TableConfig, TableData, TableCatalogInfo, TableDataRef,
             TableDesc, TableShardInfo, DEFAULT_ALLOC_STEP,
         },
         version::{TableVersionMeta, TableVersionSnapshot},
@@ -112,7 +112,7 @@ impl TableMetaSetImpl {
         &self,
         meta_update: MetaUpdate,
         shard_info: TableShardInfo,
-        extr_info: TableDataExtraneousInfo,
+        extr_info: TableCatalogInfo,
     ) -> crate::manifest::details::Result<TableDataRef> {
         match meta_update {
             MetaUpdate::AddTable(AddTableMeta {
@@ -248,7 +248,7 @@ impl TableMetaSetImpl {
         &self,
         meta_snapshot: MetaSnapshot,
         shard_info: TableShardInfo,
-        extr_info: TableDataExtraneousInfo,
+        extr_info: TableCatalogInfo,
     ) -> crate::manifest::details::Result<TableDataRef> {
         debug!("TableMetaSet apply snapshot, snapshot :{:?}", meta_snapshot);
 

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -112,7 +112,7 @@ impl TableMetaSetImpl {
         &self,
         meta_update: MetaUpdate,
         shard_info: TableShardInfo,
-        extr_info: TableCatalogInfo,
+        table_catalog_info: TableCatalogInfo,
     ) -> crate::manifest::details::Result<TableDataRef> {
         match meta_update {
             MetaUpdate::AddTable(AddTableMeta {
@@ -138,9 +138,9 @@ impl TableMetaSetImpl {
                     TableData::new(
                         TableDesc {
                             space_id: space.id,
-                            schema_id: extr_info.schema_id,
-                            schema_name: extr_info.schema_name,
-                            catalog_name: extr_info.catalog_name,
+                            schema_id: table_catalog_info.schema_id,
+                            schema_name: table_catalog_info.schema_name,
+                            catalog_name: table_catalog_info.catalog_name,
                             id: table_id,
                             name: table_name,
                             schema,
@@ -248,7 +248,7 @@ impl TableMetaSetImpl {
         &self,
         meta_snapshot: MetaSnapshot,
         shard_info: TableShardInfo,
-        extr_info: TableCatalogInfo,
+        table_catalog_info: TableCatalogInfo,
     ) -> crate::manifest::details::Result<TableDataRef> {
         debug!("TableMetaSet apply snapshot, snapshot :{:?}", meta_snapshot);
 
@@ -292,7 +292,7 @@ impl TableMetaSetImpl {
                 },
                 mem_size_options,
                 allocator,
-                extr_info,
+                table_catalog_info,
             )
             .box_err()
             .with_context(|| ApplySnapshotToTableWithCause {
@@ -383,13 +383,13 @@ impl TableMetaSet for TableMetaSetImpl {
         let MetaEditRequest {
             shard_info,
             meta_edit,
-            extr_info,
+            table_catalog_info,
         } = request;
 
         match meta_edit {
-            meta_edit::MetaEdit::Update(update) => self.apply_update(update, shard_info, extr_info),
+            meta_edit::MetaEdit::Update(update) => self.apply_update(update, shard_info, table_catalog_info),
             meta_edit::MetaEdit::Snapshot(manifest_data) => {
-                self.apply_snapshot(manifest_data, shard_info, extr_info)
+                self.apply_snapshot(manifest_data, shard_info, table_catalog_info)
             }
         }
     }

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -38,8 +38,8 @@ use crate::{
     sst::file::FilePurgerRef,
     table::{
         data::{
-            MemSizeOptions, TableConfig, TableData, TableCatalogInfo, TableDataRef,
-            TableDesc, TableShardInfo, DEFAULT_ALLOC_STEP,
+            MemSizeOptions, TableCatalogInfo, TableConfig, TableData, TableDataRef, TableDesc,
+            TableShardInfo, DEFAULT_ALLOC_STEP,
         },
         version::{TableVersionMeta, TableVersionSnapshot},
         version_edit::VersionEdit,

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -118,6 +118,7 @@ impl TableMetaSetImpl {
                 space_id,
                 table_id,
                 table_name,
+                catalog_name,
                 schema,
                 opts,
             }) => {
@@ -152,6 +153,7 @@ impl TableMetaSetImpl {
                         },
                         &self.file_purger,
                         mem_size_options,
+                        catalog_name
                     )
                     .box_err()
                     .with_context(|| ApplyUpdateToTableWithCause {
@@ -343,6 +345,7 @@ impl TableMetaSet for TableMetaSetImpl {
                 space_id,
                 table_id,
                 table_name: table_data.name.to_string(),
+                catalog_name: table_data.catalog_name.to_string(),
                 schema: table_data.schema(),
                 opts: table_data.table_options().as_ref().clone(),
             };

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -387,7 +387,9 @@ impl TableMetaSet for TableMetaSetImpl {
         } = request;
 
         match meta_edit {
-            meta_edit::MetaEdit::Update(update) => self.apply_update(update, shard_info, table_catalog_info),
+            meta_edit::MetaEdit::Update(update) => {
+                self.apply_update(update, shard_info, table_catalog_info)
+            }
             meta_edit::MetaEdit::Snapshot(manifest_data) => {
                 self.apply_snapshot(manifest_data, shard_info, table_catalog_info)
             }

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -118,7 +118,6 @@ impl TableMetaSetImpl {
                 space_id,
                 table_id,
                 table_name,
-                catalog_name,
                 schema,
                 opts,
             }) => {
@@ -153,7 +152,6 @@ impl TableMetaSetImpl {
                         },
                         &self.file_purger,
                         mem_size_options,
-                        catalog_name
                     )
                     .box_err()
                     .with_context(|| ApplyUpdateToTableWithCause {
@@ -345,7 +343,6 @@ impl TableMetaSet for TableMetaSetImpl {
                 space_id,
                 table_id,
                 table_name: table_data.name.to_string(),
-                catalog_name: table_data.catalog_name.to_string(),
                 schema: table_data.schema(),
                 opts: table_data.table_options().as_ref().clone(),
             };


### PR DESCRIPTION
## Rationale
Closes https://github.com/CeresDB/ceresdb/issues/1157

To be able to get the catalog from the table

## Detailed Changes

I added the `schema id`, `schema name`, `catalog name` to `MetaEditRequest` for passing them to `TableData`, but because `MetaEdit` involves passing the protoc protocol, I don't save them here.

## Test Plan

pass