### PR TITLE
feat: slow log include remote query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "codec",
  "common_types",
  "datafusion",
@@ -1303,7 +1303,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto 1.0.22",
+ "ceresdbproto",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1330,21 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe958e8ea5fd3da1a2449b7d49c8f8dcaa87195a1498bc7a0215794d3f236e"
-dependencies = [
- "prost",
- "protoc-bin-vendored",
- "tonic 0.8.3",
- "tonic-build",
- "walkdir",
-]
-
-[[package]]
-name = "ceresdbproto"
 version = "1.0.23"
-source = "git+https://github.com/CeresDB/horaedbproto.git?rev=dd761ee#dd761ee20550dddcb62c846c672449a9439164ed"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566b40a90db96af9274f42dd6ef088e220ffa7c306e3d3d1ed3848d2c770da99"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1527,7 +1515,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1605,7 +1593,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2360,7 +2348,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3914,7 +3902,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4439,7 +4427,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "chrono",
  "clru",
  "crc",
@@ -5316,7 +5304,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -5443,7 +5431,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "cluster",
  "codec",
  "common_types",
@@ -5754,7 +5742,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5883,7 +5871,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "cluster",
  "common_types",
  "generic_error",
@@ -6258,7 +6246,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -6784,7 +6772,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6806,7 +6794,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -7009,7 +6997,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "chrono",
  "common_types",
  "macros",
@@ -7521,8 +7509,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.3.23",
  "static_assertions",
 ]
 
@@ -7661,7 +7649,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.23",
+ "ceresdbproto",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "codec",
  "common_types",
  "datafusion",
@@ -1303,7 +1303,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.22",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1333,6 +1333,18 @@ name = "ceresdbproto"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe958e8ea5fd3da1a2449b7d49c8f8dcaa87195a1498bc7a0215794d3f236e"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic 0.8.3",
+ "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "1.0.23"
+source = "git+https://github.com/CeresDB/horaedbproto.git?rev=dd761ee#dd761ee20550dddcb62c846c672449a9439164ed"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1515,7 +1527,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1593,7 +1605,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2348,7 +2360,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3902,7 +3914,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4427,7 +4439,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "chrono",
  "clru",
  "crc",
@@ -5304,7 +5316,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "clru",
  "cluster",
  "common_types",
@@ -5431,7 +5443,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "cluster",
  "codec",
  "common_types",
@@ -5742,7 +5754,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5871,7 +5883,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "cluster",
  "common_types",
  "generic_error",
@@ -6246,7 +6258,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "clru",
  "cluster",
  "common_types",
@@ -6772,7 +6784,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6794,7 +6806,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6997,7 +7009,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "chrono",
  "common_types",
  "macros",
@@ -7649,7 +7661,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.23",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,8 +93,7 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-# ceresdbproto = "1.0.22"
-ceresdbproto = { git = "https://github.com/CeresDB/horaedbproto.git", rev = "dd761ee" }
+ceresdbproto = "1.0.23"
 codec = { path = "components/codec" }
 chrono = "0.4"
 clap = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,8 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0.22"
+# ceresdbproto = "1.0.22"
+ceresdbproto = { git = "https://github.com/CeresDB/horaedbproto.git", rev = "dd761ee" }
 codec = { path = "components/codec" }
 chrono = "0.4"
 clap = "3.0"

--- a/components/logger/src/lib.rs
+++ b/components/logger/src/lib.rs
@@ -478,9 +478,9 @@ impl<'a> Drop for SlowTimer<'a> {
         let cost = self.elapsed();
         if cost > self.slow_threshold {
             slow_query!(
-                "RequestId:{}, elapsed:{:?}, sql:{}",
-                self.request_id,
+                "Normal query elapsed:{:?}, id:{}, query:{}",
                 cost,
+                self.request_id,
                 self.sql,
             );
         }

--- a/df_engine_extensions/src/dist_sql_query/physical_plan.rs
+++ b/df_engine_extensions/src/dist_sql_query/physical_plan.rs
@@ -152,12 +152,12 @@ pub(crate) struct ResolvedPartitionedScan {
 impl ResolvedPartitionedScan {
     pub fn new(
         remote_executor: Arc<dyn RemotePhysicalPlanExecutor>,
-        sut_table_plan_ctxs: Vec<SubTablePlanContext>,
+        sub_table_plan_ctxs: Vec<SubTablePlanContext>,
         metrics_collector: MetricsCollector,
     ) -> Self {
         let remote_exec_ctx = Arc::new(RemoteExecContext {
             executor: remote_executor,
-            plan_ctxs: sut_table_plan_ctxs,
+            plan_ctxs: sub_table_plan_ctxs,
         });
 
         Self::new_with_details(remote_exec_ctx, true, metrics_collector)
@@ -456,18 +456,18 @@ impl Stream for PartitionedScanStream {
 /// stream first. The process of state changing is like:
 ///
 /// ```plaintext
-///     ┌────────────┐                                        
-///     │Initializing│                                        
-///     └──────┬─────┘                                        
+///     ┌────────────┐
+///     │Initializing│
+///     └──────┬─────┘
 ///   _________▽_________     ┌──────────────────────────────┐
 ///  ╱                   ╲    │Polling(we just return the    │
 /// ╱ Success to init the ╲___│inner stream's polling result)│
 /// ╲ record batch stream ╱yes└──────────────────────────────┘
-///  ╲___________________╱                                    
-///           │no                                            
-///  ┌────────▽───────┐                                      
-///  │InitializeFailed│                                      
-///  └────────────────┘                                      
+///  ╲___________________╱
+///           │no
+///  ┌────────▽───────┐
+///  │InitializeFailed│
+///  └────────────────┘
 /// ```
 pub(crate) enum StreamState {
     Initializing,

--- a/query_engine/src/datafusion_impl/task_context.rs
+++ b/query_engine/src/datafusion_impl/task_context.rs
@@ -192,13 +192,12 @@ impl RemotePhysicalPlanExecutor for RemotePhysicalPlanExecutorImpl {
         let default_schema = ceresdb_options.default_schema.clone();
 
         let display_plan = DisplayableExecutionPlan::new(plan.as_ref());
-        let sql = display_plan.indent(true).to_string();
         let exec_ctx = ExecContext {
             request_id,
             deadline,
             default_catalog,
             default_schema,
-            sql,
+            query: display_plan.indent(true).to_string(),
         };
 
         // Encode plan and schema

--- a/query_engine/src/datafusion_impl/task_context.rs
+++ b/query_engine/src/datafusion_impl/task_context.rs
@@ -24,7 +24,7 @@ use common_types::{request_id::RequestId, schema::RecordSchema};
 use datafusion::{
     error::{DataFusionError, Result as DfResult},
     execution::{runtime_env::RuntimeEnv, FunctionRegistry, TaskContext},
-    physical_plan::{ExecutionPlan, SendableRecordBatchStream},
+    physical_plan::{display::DisplayableExecutionPlan, ExecutionPlan, SendableRecordBatchStream},
 };
 use datafusion_proto::{
     bytes::physical_plan_to_bytes_with_extension_codec,
@@ -191,11 +191,14 @@ impl RemotePhysicalPlanExecutor for RemotePhysicalPlanExecutorImpl {
         let default_catalog = ceresdb_options.default_catalog.clone();
         let default_schema = ceresdb_options.default_schema.clone();
 
+        let display_plan = DisplayableExecutionPlan::new(plan.as_ref());
+        let sql = display_plan.indent(true).to_string();
         let exec_ctx = ExecContext {
             request_id,
             deadline,
             default_catalog,
             default_schema,
+            sql,
         };
 
         // Encode plan and schema

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -41,13 +41,14 @@ use futures::{
     Future,
 };
 use generic_error::BoxError;
-use logger::{error, info};
+use logger::{error, info, slow_query};
 use notifier::notifier::{ExecutionGuard, RequestNotifiers, RequestResult};
 use proxy::{
     hotspot::{HotspotRecorder, Message},
     instance::InstanceRef,
 };
 use query_engine::{
+    context::Context as QueryContext,
     datafusion_impl::physical_plan::{DataFusionPhysicalPlanAdapter, TypedPlan},
     QueryEngineRef, QueryEngineType,
 };
@@ -124,13 +125,38 @@ impl MetricCollector for StreamReadMetricCollector {
     }
 }
 
-struct ExecutePlanMetricCollector(Instant);
+struct ExecutePlanMetricCollector {
+    start: Instant,
+    sql: String,
+    request_id: RequestId,
+    slow_threshold: Duration,
+}
+
+impl ExecutePlanMetricCollector {
+    fn new(request_id: u64, sql: String, slow_threshold_secs: u64) -> Self {
+        Self {
+            start: Instant::now(),
+            sql,
+            request_id: request_id.into(),
+            slow_threshold: Duration::from_secs(slow_threshold_secs),
+        }
+    }
+}
 
 impl MetricCollector for ExecutePlanMetricCollector {
     fn collect(self) {
+        let cost = self.start.elapsed();
+        if cost > self.slow_threshold {
+            slow_query!(
+                "Remote request, id:{}, elapsed:{:?}, sql:{}",
+                self.request_id,
+                cost,
+                self.sql
+            );
+        }
         REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
             .execute_physical_plan
-            .observe(self.0.saturating_elapsed().as_secs_f64());
+            .observe(cost.as_secs_f64());
     }
 }
 
@@ -580,15 +606,28 @@ impl RemoteEngineServiceImpl {
         &self,
         request: Request<ExecutePlanRequest>,
     ) -> Result<StreamWithMetric<ExecutePlanMetricCollector>> {
-        let metric = ExecutePlanMetricCollector(Instant::now());
         let request = request.into_inner();
         let query_engine = self.instance.query_engine.clone();
         let (ctx, encoded_plan) = extract_plan_from_req(request)?;
+        let slow_threshold_secs = self
+            .instance
+            .dyn_config
+            .slow_threshold
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        let metric =
+            ExecutePlanMetricCollector::new(ctx.request_id.into(), ctx.sql, slow_threshold_secs);
+        let query_ctx = create_query_ctx(
+            ctx.request_id,
+            ctx.default_catalog,
+            ctx.default_schema,
+            ctx.timeout_ms,
+        );
 
         let stream = self
             .runtimes
             .read_runtime
-            .spawn(async move { handle_execute_plan(ctx, encoded_plan, query_engine).await })
+            .spawn(async move { handle_execute_plan(query_ctx, encoded_plan, query_engine).await })
             .await
             .box_err()
             .with_context(|| ErrWithCause {
@@ -610,11 +649,26 @@ impl RemoteEngineServiceImpl {
         query_dedup: QueryDedup,
         request: Request<ExecutePlanRequest>,
     ) -> Result<StreamWithMetric<ExecutePlanMetricCollector>> {
-        let metric = ExecutePlanMetricCollector(Instant::now());
         let request = request.into_inner();
-
         let query_engine = self.instance.query_engine.clone();
         let (ctx, encoded_plan) = extract_plan_from_req(request)?;
+        let slow_threshold_secs = self
+            .instance
+            .dyn_config
+            .slow_threshold
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let metric = ExecutePlanMetricCollector::new(
+            ctx.request_id.into(),
+            ctx.sql.clone(),
+            slow_threshold_secs,
+        );
+        let query_ctx = create_query_ctx(
+            ctx.request_id,
+            ctx.default_catalog,
+            ctx.default_schema,
+            ctx.timeout_ms,
+        );
+
         let key = PhysicalPlanKey {
             encoded_plan: encoded_plan.clone(),
         };
@@ -630,7 +684,7 @@ impl RemoteEngineServiceImpl {
             // The first request, need to handle it, and then notify the other requests.
             RequestResult::First => {
                 let query = async move {
-                    handle_execute_plan(ctx, encoded_plan, query_engine)
+                    handle_execute_plan(query_ctx, encoded_plan, query_engine)
                         .await
                         .map(PartitionedStreams::one_stream)
                 };
@@ -1039,18 +1093,12 @@ fn extract_plan_from_req(request: ExecutePlanRequest) -> Result<(ExecContext, Ve
     Ok((ctx_in_req, valid_plan))
 }
 
-async fn handle_execute_plan(
-    ctx: ExecContext,
-    encoded_plan: Vec<u8>,
-    query_engine: QueryEngineRef,
-) -> Result<SendableRecordBatchStream> {
-    let ExecContext {
-        request_id,
-        default_catalog,
-        default_schema,
-        timeout_ms,
-    } = ctx;
-
+fn create_query_ctx(
+    request_id: u64,
+    default_catalog: String,
+    default_schema: String,
+    timeout_ms: i64,
+) -> QueryContext {
     let request_id = RequestId::from(request_id);
     let deadline = if timeout_ms >= 0 {
         Some(Instant::now() + Duration::from_millis(timeout_ms as u64))
@@ -1058,13 +1106,19 @@ async fn handle_execute_plan(
         None
     };
 
-    let exec_ctx = query_engine::context::Context {
+    QueryContext {
         request_id,
         deadline,
         default_catalog,
         default_schema,
-    };
+    }
+}
 
+async fn handle_execute_plan(
+    ctx: QueryContext,
+    encoded_plan: Vec<u8>,
+    query_engine: QueryEngineRef,
+) -> Result<SendableRecordBatchStream> {
     // TODO: Build remote plan in physical planner.
     let physical_plan = Box::new(DataFusionPhysicalPlanAdapter::new(TypedPlan::Remote(
         encoded_plan,
@@ -1073,7 +1127,7 @@ async fn handle_execute_plan(
     // Execute plan.
     let executor = query_engine.executor();
     executor
-        .execute(&exec_ctx, physical_plan)
+        .execute(&ctx, physical_plan)
         .await
         .box_err()
         .with_context(|| ErrWithCause {

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -447,6 +447,7 @@ pub struct ExecContext {
     pub deadline: Option<Instant>,
     pub default_catalog: String,
     pub default_schema: String,
+    pub sql: String,
 }
 
 pub enum PhysicalPlan {
@@ -466,6 +467,8 @@ impl From<RemoteExecuteRequest> for ceresdbproto::remote_engine::ExecutePlanRequ
             default_catalog: value.context.default_catalog,
             default_schema: value.context.default_schema,
             timeout_ms: rest_duration_ms,
+            priority: 0, // not used now
+            sql: value.context.sql,
         };
 
         let pb_plan = match value.physical_plan {
@@ -505,6 +508,8 @@ impl TryFrom<ceresdbproto::remote_engine::ExecutePlanRequest> for RemoteExecuteR
             default_catalog,
             default_schema,
             timeout_ms,
+            sql,
+            ..
         } = pb_exec_ctx;
 
         let request_id = RequestId::from(request_id);
@@ -519,6 +524,7 @@ impl TryFrom<ceresdbproto::remote_engine::ExecutePlanRequest> for RemoteExecuteR
             deadline,
             default_catalog,
             default_schema,
+            sql,
         };
 
         // Plan

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -447,7 +447,7 @@ pub struct ExecContext {
     pub deadline: Option<Instant>,
     pub default_catalog: String,
     pub default_schema: String,
-    pub sql: String,
+    pub query: String,
 }
 
 pub enum PhysicalPlan {
@@ -468,7 +468,7 @@ impl From<RemoteExecuteRequest> for ceresdbproto::remote_engine::ExecutePlanRequ
             default_schema: value.context.default_schema,
             timeout_ms: rest_duration_ms,
             priority: 0, // not used now
-            sql: value.context.sql,
+            displayable_query: value.context.query,
         };
 
         let pb_plan = match value.physical_plan {
@@ -508,7 +508,7 @@ impl TryFrom<ceresdbproto::remote_engine::ExecutePlanRequest> for RemoteExecuteR
             default_catalog,
             default_schema,
             timeout_ms,
-            sql,
+            displayable_query,
             ..
         } = pb_exec_ctx;
 
@@ -524,7 +524,7 @@ impl TryFrom<ceresdbproto::remote_engine::ExecutePlanRequest> for RemoteExecuteR
             deadline,
             default_catalog,
             default_schema,
-            sql,
+            query: displayable_query,
         };
 
         // Plan


### PR DESCRIPTION
## Rationale
Currently slow log won't record query from remote engine, this makes it's hard to explain which query has the most vital effect on current server.

## Detailed Changes
- Add displayable plan in remote query request, and add to slow log

## Test Plan
Manually

