### PR TITLE
chore(license): rename `license-header.txt`'s CeresDB to HoraeDB

### DIFF
--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,4 +1,4 @@
-Copyright 2023 The CeresDB Authors
+Copyright 2023 The HoraeDB Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Rationale
Related  https://github.com/CeresDB/horaedb/issues/1319

## Detailed Changes
update `license-header.txt`'s org

## Test Plan
UT.