### PR TITLE
fix: duplicate key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5809,6 +5809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "resource_keeper"
+version = "1.2.6-alpha"
+dependencies = [
+ "logger",
+ "tokio",
+ "tokio-test",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ router = { path = "router" }
 runtime = { path = "components/runtime" }
 sampling_cache = { path = "components/sampling_cache" }
 snafu = { version = "0.6.10", features = ["backtraces"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
 server = { path = "server" }
 size_ext = { path = "components/size_ext" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "components/parquet_ext",
     "components/partitioned_lock",
     "components/profile",
+    "components/resource_keeper",
     "components/runtime",
     "components/sampling_cache",
     "components/size_ext",
@@ -149,6 +150,7 @@ query_engine = { path = "query_engine" }
 query_frontend = { path = "query_frontend" }
 rand = "0.7"
 remote_engine_client = { path = "remote_engine_client" }
+resource_keeper = { path = "components/resource_keeper" }
 reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls",
     "json",

--- a/analytic_engine/src/instance/wal_replayer.rs
+++ b/analytic_engine/src/instance/wal_replayer.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Copyright 2023 The HoraeDB Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -542,12 +556,12 @@ async fn replay_table_log_entries(
                 }
 
                 // Flush the table if necessary.
-                if table_data.should_flush_table(serial_exec) {
+                let flush_scheduler = serial_exec.flush_scheduler();
+                if table_data.should_flush_table(flush_scheduler.is_in_flush()) {
                     let opts = TableFlushOptions {
                         res_sender: None,
                         max_retry_flush_limit,
                     };
-                    let flush_scheduler = serial_exec.flush_scheduler();
                     flusher
                         .schedule_flush(flush_scheduler, table_data, opts)
                         .await

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Copyright 2023 The HoraeDB Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -620,7 +634,8 @@ impl<'a> Writer<'a> {
             }
         }
 
-        if self.table_data.should_flush_table(self.serial_exec) {
+        let in_flush = self.serial_exec.flush_scheduler().is_in_flush();
+        if self.table_data.should_flush_table(in_flush) {
             let table_data = self.table_data.clone();
             let _timer = table_data.metrics.start_table_write_flush_wait_timer();
             self.handle_memtable_flush(&table_data).await?;

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Copyright 2023 The HoraeDB Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -584,9 +598,7 @@ impl TableData {
     }
 
     /// Returns true if the memory usage of this table reaches flush threshold
-    ///
-    /// REQUIRE: Do in write worker
-    pub fn should_flush_table(&self, serial_exec: &mut TableOpSerialExecutor) -> bool {
+    pub fn should_flush_table(&self, in_flush: bool) -> bool {
         // Fallback to usize::MAX if Failed to convert arena_block_size into
         // usize (overflow)
         let max_write_buffer_size = self
@@ -602,7 +614,6 @@ impl TableData {
 
         let mutable_usage = self.current_version.mutable_memory_usage();
         let total_usage = self.current_version.total_memory_usage();
-        let in_flush = serial_exec.flush_scheduler().is_in_flush();
         // Inspired by https://github.com/facebook/rocksdb/blob/main/include/rocksdb/write_buffer_manager.h#L94
         if mutable_usage > mutable_limit && !in_flush {
             info!(

--- a/components/resource_keeper/Cargo.toml
+++ b/components/resource_keeper/Cargo.toml
@@ -1,0 +1,35 @@
+# Copyright 2023 The HoraeDB Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "resource_keeper"
+
+[package.license]
+workspace = true
+
+[package.version]
+workspace = true
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
+
+[dependencies]
+logger = { workspace = true }
+tokio  = { workspace = true }
+
+[dev-dependencies]
+tokio-test = "0.4.2"

--- a/components/resource_keeper/src/lib.rs
+++ b/components/resource_keeper/src/lib.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2023 The HoraeDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    ops::Deref,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use logger::{info, warn};
+
+#[derive(Default)]
+struct State {
+    ref_count: u32,
+    invalid: bool,
+}
+
+pub struct ResourceGuard<'a, T: Send + Sync> {
+    resource: &'a T,
+    state: Arc<Mutex<State>>,
+}
+
+impl<'a, T: Send + Sync> Deref for ResourceGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &'a T {
+        self.resource
+    }
+}
+
+impl<'a, T: Send + Sync> Drop for ResourceGuard<'a, T> {
+    fn drop(&mut self) {
+        self.state.lock().unwrap().ref_count -= 1;
+    }
+}
+
+pub struct ResourceKeeper<T: Send + Sync> {
+    resource: T,
+    state: Arc<Mutex<State>>,
+
+    name: String,
+    check_release_interval: Duration,
+}
+
+impl<T: Send + Sync> ResourceKeeper<T> {
+    pub fn new(name: String, resource: T, check_release_interval: Duration) -> Self {
+        Self {
+            resource,
+            state: Arc::new(Mutex::new(State::default())),
+
+            name,
+            check_release_interval,
+        }
+    }
+
+    pub fn try_acquire(&self) -> Option<ResourceGuard<'_, T>> {
+        {
+            let mut state = self.state.lock().unwrap();
+            if state.invalid {
+                return None;
+            }
+            state.ref_count += 1;
+        }
+
+        let guard = ResourceGuard {
+            resource: &self.resource,
+            state: self.state.clone(),
+        };
+        Some(guard)
+    }
+
+    pub async fn wait_release(&self) {
+        // Set the state is invalid to avoid future acquire.
+        {
+            let mut state = self.state.lock().unwrap();
+            state.invalid = true;
+        }
+
+        // Wait until all the resource references are dropped.
+        let mut wait_cnt = 0;
+        while !self.check_released_once() {
+            wait_cnt += 1;
+            if wait_cnt % 100 == 0 {
+                warn!(
+                    "Resource {} is still in use, wait for release {wait_cnt} times",
+                    self.name
+                );
+            }
+            tokio::time::sleep(self.check_release_interval).await;
+        }
+
+        info!(
+            "Resource {} is released, waited for {:?}",
+            self.name,
+            wait_cnt * self.check_release_interval
+        );
+    }
+
+    #[inline]
+    fn check_released_once(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        state.ref_count == 0
+    }
+}


### PR DESCRIPTION
## Rationale
Close #1205

## Detailed Changes
Introduce such mechanism to ensure the shared storage won't be still in use after table is closed:
Do reference count for the table-level usage of the wal & object store (shared storages), and wait for all the references dropped before close table.

## Test Plan
- Should pass all the tests in the ci.
- The relevant logs should occur when table is closed.