### PR TITLE
fix: ensure channel size non zero

### DIFF
--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -732,6 +732,7 @@ impl<'a> SstReader for ThreadedReader<'a> {
         );
 
         let channel_cap_per_sub_reader = self.channel_cap / sub_readers.len();
+        let channel_cap_per_sub_reader = channel_cap_per_sub_reader.max(1);
         let (tx_group, rx_group): (Vec<_>, Vec<_>) = (0..read_parallelism)
             .map(|_| mpsc::channel::<Result<RecordBatchWithKey>>(channel_cap_per_sub_reader))
             .unzip();

--- a/integration_tests/build_meta.sh
+++ b/integration_tests/build_meta.sh
@@ -8,7 +8,7 @@ META_BIN_PATH=${META_BIN_PATH:-""}
 
 if [[ -z "${META_BIN_PATH}" ]]; then
     echo "Fetch and install ceresmeta-server..."
-    go install -a github.com/CeresDB/horaemeta/cmd/ceresmeta-server@dev
+    go install -v -a github.com/CeresDB/ceresmeta/cmd/ceresmeta-server@dev
     META_BIN_PATH="$(go env GOPATH)/bin/ceresmeta-server"
 fi
 

--- a/integration_tests/build_meta.sh
+++ b/integration_tests/build_meta.sh
@@ -8,7 +8,7 @@ META_BIN_PATH=${META_BIN_PATH:-""}
 
 if [[ -z "${META_BIN_PATH}" ]]; then
     echo "Fetch and install ceresmeta-server..."
-    go install -a github.com/CeresDB/horaemeta/cmd/ceresmeta-server@main
+    go install -a github.com/CeresDB/horaemeta/cmd/ceresmeta-server@dev
     META_BIN_PATH="$(go env GOPATH)/bin/ceresmeta-server"
 fi
 


### PR DESCRIPTION
## Rationale
When channel capacity < read_parallelism,  we will pass 0 to channel, which will cause panic
```
2023-12-05 20:31:32.974 ERRO [components/panic_ext/src/lib.rs:54] thread 'ceres-read' panicked 'mpsc bounded channel requires buffer > 0' at "analytic_engine/src/sst/parquet/async_reader.rs:736"
```

## Detailed Changes
- Ensure channel size non zero

## Test Plan
No need.