### PR TITLE
chore: disable block for http api

### DIFF
--- a/proxy/src/grpc/sql_query.rs
+++ b/proxy/src/grpc/sql_query.rs
@@ -104,6 +104,7 @@ impl Proxy {
                     schema,
                     &req.sql,
                     self.sub_table_access_perm.enable_others,
+                    true,
                 )
                 .await?
             }
@@ -170,6 +171,7 @@ impl Proxy {
                 schema,
                 &req.sql,
                 self.sub_table_access_perm.enable_others,
+                true,
             )
             .await?;
 

--- a/proxy/src/http/sql.rs
+++ b/proxy/src/http/sql.rs
@@ -55,6 +55,7 @@ impl Proxy {
                 schema,
                 &req.query,
                 self.sub_table_access_perm.enable_http,
+                false,
             )
             .await;
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -523,14 +523,6 @@ impl Proxy {
         plan: Plan,
         deadline: Option<Instant>,
     ) -> Result<Output> {
-        self.instance
-            .limiter
-            .try_limit(&plan)
-            .box_err()
-            .context(Internal {
-                msg: "Request is blocked",
-            })?;
-
         let interpreter =
             self.build_interpreter(request_id, catalog, schema, plan, deadline, false)?;
         Self::interpreter_execute_plan(interpreter, deadline).await
@@ -544,14 +536,6 @@ impl Proxy {
         plan: Plan,
         deadline: Option<Instant>,
     ) -> Result<Output> {
-        self.instance
-            .limiter
-            .try_limit(&plan)
-            .box_err()
-            .context(Internal {
-                msg: "Request is blocked",
-            })?;
-
         let interpreter =
             self.build_interpreter(request_id, catalog, schema, plan, deadline, true)?;
         Self::interpreter_execute_plan(interpreter, deadline).await


### PR DESCRIPTION
## Rationale
HTTP API is mainly used for debugging, and should not be blocked.

## Detailed Changes


## Test Plan
Pass CI

